### PR TITLE
Feature-motor-beep-on-aux-channel

### DIFF
--- a/script/targets.json
+++ b/script/targets.json
@@ -1,5 +1,17 @@
 [
   {
+    "name": "aikon_f4",
+    "configurations": [
+      {
+        "name": "brushed.serial",
+        "defines": {
+          "BRUSHED_TARGET": "",
+          "RX_UNIFIED_SERIAL": ""
+        }
+      }
+    ]
+  },
+  {
     "name": "alienwhoop_v2",
     "configurations": [
       {

--- a/src/drivers/drv_motor_dshot_dma_f4.c
+++ b/src/drivers/drv_motor_dshot_dma_f4.c
@@ -435,13 +435,13 @@ void motor_set(uint8_t number, float pwm) {
 
 void motor_beep() {
   static uint32_t motor_beep_time = 0;
-  if (flags.failsafe) {
+  if (flags.failsafe || rx_aux_on(AUX_BUZZER_ENABLE)) {
     uint32_t time = timer_micros();
     if (motor_beep_time == 0) {
       motor_beep_time = time;
     }
     const uint32_t delta_time = time - motor_beep_time;
-    if (delta_time > MOTOR_BEEPS_TIMEOUT) {
+    if (delta_time > MOTOR_BEEPS_TIMEOUT || rx_aux_on(AUX_BUZZER_ENABLE)) {
       uint8_t beep_command = 0;
       if (delta_time % 2000000 < 250000) {
         beep_command = DSHOT_CMD_BEEP1;

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -264,7 +264,7 @@
 //***********************************************ADDITIONAL FEATURES****************************************************
 
 // *************lost quad beeps using motors (30 sec timeout) - pulses motors after timeout period to help find a lost model
-//#define MOTOR_BEEPS
+#define MOTOR_BEEPS
 //#define MOTOR_BEEPS_TIMEOUT 1e6
 
 // *************enable inverted flight code ( brushless only ) - WARNING - NEVER TESTED


### PR DESCRIPTION
Allow to switch motor beep via aux channel AUX_BUZZER_ENABLE. This is useful when flying outdoor on low weight aircrafts where installing separate buzzer is not desirable. Works with DSHOT protocol only.