### PR TITLE
Add option to make angle yaw not around gravity

### DIFF
--- a/src/main/angle_pid.c
+++ b/src/main/angle_pid.c
@@ -17,18 +17,21 @@ static float apidoutput[ANGLE_PID_SIZE];
 static float lasterror[ANGLE_PID_SIZE];
 
 float angle_pid(int x) {
+  float inverse_angle_error = 1 - fabsf(state.angleerror[x]);
+  float abs_angle_error = fabsf(state.angleerror[x]);
+
   // P term 1 weighted
-  apidoutput1[x] = (1 - fabsf(state.angleerror[x])) * state.angleerror[x] * profile.pid.small_angle.kp;
+  apidoutput1[x] = inverse_angle_error * state.angleerror[x] * profile.pid.small_angle.kp;
 
   // P term 2 weighted
-  apidoutput2[x] = fabsf(state.angleerror[x]) * state.angleerror[x] * profile.pid.big_angle.kp;
+  apidoutput2[x] = abs_angle_error * state.angleerror[x] * profile.pid.big_angle.kp;
 
   extern float timefactor;
   // D term 1 weighted + P term 1 weighted
-  apidoutput1[x] += (state.angleerror[x] - lasterror[x]) * profile.pid.small_angle.kd * (1 - fabsf(state.angleerror[x])) * timefactor;
+  apidoutput1[x] += (state.angleerror[x] - lasterror[x]) * profile.pid.small_angle.kd * inverse_angle_error * timefactor;
 
   // D term 2 weighted + P term 2 weighted
-  apidoutput2[x] += ((state.angleerror[x] - lasterror[x]) * profile.pid.big_angle.kd * fabsf(state.angleerror[x]) * timefactor);
+  apidoutput2[x] += ((state.angleerror[x] - lasterror[x]) * profile.pid.big_angle.kd * abs_angle_error * timefactor);
 
   // apidoutput sum
   apidoutput[x] = apidoutput1[x] + apidoutput2[x];

--- a/src/main/angle_pid.c
+++ b/src/main/angle_pid.c
@@ -17,8 +17,8 @@ static float apidoutput[ANGLE_PID_SIZE];
 static float lasterror[ANGLE_PID_SIZE];
 
 float angle_pid(int x) {
-  float inverse_angle_error = 1 - fabsf(state.angleerror[x]);
-  float abs_angle_error = fabsf(state.angleerror[x]);
+  const float inverse_angle_error = 1 - fabsf(state.angleerror[x]);
+  const float abs_angle_error = fabsf(state.angleerror[x]);
 
   // P term 1 weighted
   apidoutput1[x] = inverse_angle_error * state.angleerror[x] * profile.pid.small_angle.kp;

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -54,6 +54,7 @@
 
 // *************max angle for level mode
 #define LEVEL_MAX_ANGLE 65.0f
+#define ANGLE_AROUND_GRAVITY
 
 // ************* low rates multiplier if rates are assigned to a channel
 #define LOW_RATES_MULTI 0.5f

--- a/src/main/control.c
+++ b/src/main/control.c
@@ -154,14 +154,18 @@ void control(void) {
     // *************************************************************************
     // *************************************************************************
 
-    if (rx_aux_on(AUX_RACEMODE) && !rx_aux_on(AUX_HORIZON)) { //racemode with angle behavior on roll ais
+    if (rx_aux_on(AUX_RACEMODE) && !rx_aux_on(AUX_HORIZON)) { // racemode with angle behavior on roll axis
       if (state.GEstG.axis[2] < 0) {                          // acro on roll and pitch when inverted
         state.error.axis[0] = rates[0] - state.gyro.axis[0];
         state.error.axis[1] = rates[1] - state.gyro.axis[1];
       } else {
         //roll is leveled to max angle limit
         state.angleerror[0] = state.errorvect.axis[0];
+#ifdef ANGLE_AROUND_GRAVITY
         state.error.axis[0] = angle_pid(0) + yawerror[0] - state.gyro.axis[0];
+#else
+        state.error.axis[0] = angle_pid(0) - state.gyro.axis[0];
+#endif
         //pitch is acro
         state.error.axis[1] = rates[1] - state.gyro.axis[1];
       }
@@ -249,7 +253,11 @@ void control(void) {
       // pitch and roll
       for (int i = 0; i <= 1; i++) {
         state.angleerror[i] = state.errorvect.axis[i];
+#ifdef ANGLE_AROUND_GRAVITY
         state.error.axis[i] = angle_pid(i) + yawerror[i] - state.gyro.axis[i];
+#else
+        state.error.axis[i] = angle_pid(i) - state.gyro.axis[i];
+#endif
       }
       // yaw
       state.error.axis[2] = yawerror[2] - state.gyro.axis[2];

--- a/src/main/input.c
+++ b/src/main/input.c
@@ -50,10 +50,15 @@ void input_stick_vector(float rx_input[], float maxangle) {
 #endif
   }
 
+#ifdef ANGLE_AROUND_GRAVITY
   // find error between stick vector and quad orientation
   // vector cross product
   state.errorvect.axis[1] = -((state.GEstG.axis[1] * stickvector[2]) - (state.GEstG.axis[2] * stickvector[1]));
   state.errorvect.axis[0] = (state.GEstG.axis[2] * stickvector[0]) - (state.GEstG.axis[0] * stickvector[2]);
+#else
+  state.errorvect.axis[1] = -((state.GEstG.axis[1] * pitch) - (state.GEstG.axis[2] * pitch));
+  state.errorvect.axis[0] = (state.GEstG.axis[2] * roll) - (state.GEstG.axis[0] * roll);
+#endif
 
   // some limits just in case
 


### PR DESCRIPTION
Add an option to make angle mode yaw act on the quads yaw rather than gravities yaw. This will add an option to allow for more of an Emu/BF feel to angle mode. Won't effect how well QS handles crashes or any other angle mode improvements QS has made. From personal experience Emu users tend to prefer this yaw feeling compared to the yaw around gravity feeling. Would be a nice option to help with adoption. And no this isn't an effort to make this like BF or to copy BF. Its simply an effort to allow me to more happily convert my whoops over to QS, haha.