### PR TITLE
Changes to iterm relax and adding direct FF

### DIFF
--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -1,6 +1,8 @@
 
+#define KDFF_ROLL 0.0f // TODO, move and allow tunable, just unsure how atm
+#define KDFF_PITCH 0.0f
+#define KDFF_YAW 0.000286479f
 
-//Universal pids are already loaded for 5" brushless by default.  Adjust pids in pid.c file for your build.
 
 //**********************************************************************************************************************
 //***********************************************HARDWARE SELECTION*****************************************************

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -257,8 +257,12 @@
 
 //**************I-term relax.  Removes roll and pitch bounce back after flips
 #define I_TERM_RELAX
-//#define RELAX_FACTOR 10
-//#define RELAX_FREQUENCY_HZ 20
+#define RELAX_FACTOR 35 * 0.01745329251 // convert to rad
+#define RELAX_FREQUENCY_HZ 11 // from my experience the frequency is better to tune than the factor
+
+#define I_TERM_RELAX_YAW // adds iterm relax to yaw with its own values as it responds much different
+#define RELAX_FACTOR_YAW 35 * 0.01745329251 // convert to rad
+#define RELAX_FREQUENCY_HZ_YAW 25
 
 //**********************************************************************************************************************
 //***********************************************ADDITIONAL FEATURES****************************************************

--- a/src/main/control.c
+++ b/src/main/control.c
@@ -156,18 +156,25 @@ void control() {
     // *************************************************************************
     // *************************************************************************
 
-    if (rx_aux_on(AUX_RACEMODE) && !rx_aux_on(AUX_HORIZON)) { //racemode with angle behavior on roll ais
+    if (rx_aux_on(AUX_RACEMODE) && !rx_aux_on(AUX_HORIZON)) { // racemode with angle behavior on roll ais
       if (state.GEstG.axis[2] < 0) {                          // acro on roll and pitch when inverted
+        state.setpoint.axis[0] = rates[0];
+        state.setpoint.axis[1] = rates[1];
+
         state.error.axis[0] = rates[0] - state.gyro.axis[0];
         state.error.axis[1] = rates[1] - state.gyro.axis[1];
       } else {
-        //roll is leveled to max angle limit
+        // roll is leveled to max angle limit
         state.angleerror[0] = state.errorvect.axis[0];
-        state.error.axis[0] = angle_pid(0) + yawerror[0] - state.gyro.axis[0];
-        //pitch is acro
+        state.setpoint.axis[0] = angle_pid(0) + yawerror[0];
+        state.error.axis[0] = state.setpoint.axis[0] - state.gyro.axis[0];
+
+        // pitch is acro
+        state.setpoint.axis[1] = rates[1];
         state.error.axis[1] = rates[1] - state.gyro.axis[1];
       }
       // yaw
+      state.setpoint.axis[2] = rates[2];
       state.error.axis[2] = yawerror[2] - state.gyro.axis[2];
 
     } else if (rx_aux_on(AUX_RACEMODE) && rx_aux_on(AUX_HORIZON)) { //racemode with horizon behavior on roll axis
@@ -196,17 +203,22 @@ void control() {
       float fade = (stickFade * (1 - HORIZON_SLIDER)) + (HORIZON_SLIDER * angleFade);
       // apply acro to roll for inverted behavior
       if (state.GEstG.axis[2] < 0) {
+        state.setpoint.axis[0] = rates[0];
+        state.setpoint.axis[1] = rates[1];
         state.error.axis[0] = rates[0] - state.gyro.axis[0];
         state.error.axis[1] = rates[1] - state.gyro.axis[1];
       } else { // apply a transitioning mix of acro and level behavior inside of stick HORIZON_TRANSITION point and full acro beyond stick HORIZON_TRANSITION point
         state.angleerror[0] = state.errorvect.axis[0];
         // roll angle strength fades out as sticks approach HORIZON_TRANSITION while acro stength fades in according to value of acroFade factor
+        state.setpoint.axis[0] = (angle_pid(0) + yawerror[0]) * (1.0f - fade) + fade * (rates[0]);
         state.error.axis[0] = ((angle_pid(0) + yawerror[0] - state.gyro.axis[0]) * (1 - fade)) + (fade * (rates[0] - state.gyro.axis[0]));
         //pitch is acro
+        state.setpoint.axis[1] = rates[1];
         state.error.axis[1] = rates[1] - state.gyro.axis[1];
       }
 
       // yaw
+      state.setpoint.axis[2] = rates[2];
       state.error.axis[2] = yawerror[2] - state.gyro.axis[2];
 
     } else if (!rx_aux_on(AUX_RACEMODE) && rx_aux_on(AUX_HORIZON)) { //horizon overrites standard level behavior
@@ -237,23 +249,27 @@ void control() {
         float fade = (stickFade * (1 - HORIZON_SLIDER)) + (HORIZON_SLIDER * angleFade);
         // apply acro to roll and pitch sticks for inverted behavior
         if (state.GEstG.axis[2] < 0) {
+          state.setpoint.axis[i] = rates[i];
           state.error.axis[i] = rates[i] - state.gyro.axis[i];
         } else { // apply a transitioning mix of acro and level behavior inside of stick HORIZON_TRANSITION point and full acro beyond stick HORIZON_TRANSITION point
           state.angleerror[i] = state.errorvect.axis[i];
           //  angle strength fades out as sticks approach HORIZON_TRANSITION while acro stength fades in according to value of acroFade factor
+          state.setpoint.axis[i] = (angle_pid(i) + yawerror[i]) * (1.0f - fade) + fade * (rates[i]);
           state.error.axis[i] = ((angle_pid(i) + yawerror[i] - state.gyro.axis[i]) * (1 - fade)) + (fade * (rates[i] - state.gyro.axis[i]));
         }
       }
       // yaw
+      state.setpoint.axis[2] = rates[2];
       state.error.axis[2] = yawerror[2] - state.gyro.axis[2];
-
     } else { //standard level mode
       // pitch and roll
       for (int i = 0; i <= 1; i++) {
         state.angleerror[i] = state.errorvect.axis[i];
-        state.error.axis[i] = angle_pid(i) + yawerror[i] - state.gyro.axis[i];
+        state.setpoint.axis[i] = angle_pid(i) + yawerror[i];
+        state.error.axis[i] = state.setpoint.axis[i] - state.gyro.axis[i];
       }
       // yaw
+      state.setpoint.axis[2] = rates[2];
       state.error.axis[2] = yawerror[2] - state.gyro.axis[2];
     }
   } else { // rate mode

--- a/src/main/pid.c
+++ b/src/main/pid.c
@@ -32,10 +32,10 @@
 #ifdef BRUSHLESS_TARGET
 
 /// output limit
-const float outlimit[PID_SIZE] = {0.8, 0.8, 0.4};
+const float outlimit[PID_SIZE] = {1.0, 1.0, 1.0};
 
 // limit of integral term (abs)
-const float integrallimit[PID_SIZE] = {0.8, 0.8, 0.4};
+const float integrallimit[PID_SIZE] = {0.8, 0.8, 0.6};
 
 #else // BRUSHED TARGET
 

--- a/src/main/pid.c
+++ b/src/main/pid.c
@@ -150,33 +150,44 @@ static void pid(uint8_t x) {
     ierror[x] *= 0.98f;
   }
 
-  int iwindup = 0; // (iwidup = 0  windup is permitted)   (iwindup = 1 windup is squashed)
+  float iwindup = 0.0f; // (iwindup = 0  windup is not allowed)   (iwindup = 1 windup is allowed)
   if ((state.pidoutput.axis[x] >= outlimit[x]) && (state.error.axis[x] > 0)) {
-    iwindup = 1;
+    iwindup = 0.0f;
   }
 
   if ((state.pidoutput.axis[x] == -outlimit[x]) && (state.error.axis[x] < 0)) {
-    iwindup = 1;
+    iwindup = 0.0f;
   }
 
 #ifdef I_TERM_RELAX //  Roll - Pitch  Setpoint based I term relax method
-  static float avgSetpoint[2];
-  if (x < 2) {
-    lpf(&avgSetpoint[x], state.setpoint.axis[x], FILTERCALC(state.looptime, 1.0f / (float)RELAX_FREQUENCY_HZ)); // 20 Hz filter
-    const float hpfSetpoint = state.setpoint.axis[x] - avgSetpoint[x];
-    if (fabsf(hpfSetpoint) > (float)RELAX_FACTOR * 1e-2f) {
-      iwindup = 1;
+  static float avgSetpoint[3];
+  if (iwindup != 0.0f) {
+    if (x < 2) {
+      lpf(&avgSetpoint[x], state.setpoint.axis[x], FILTERCALC(state.looptime, 1.0f / (float)RELAX_FREQUENCY_HZ)); // 11 Hz filter
+      const float hpfSetpoint = state.setpoint.axis[x] - avgSetpoint[x];
+      iwindup = 1.0f - hpfSetpoint / RELAX_FACTOR;
+      if (iwindup < 0.0f) {
+        iwindup = 0.0;
+      }
     }
+#ifdef ITERM_RELAX_YAW
+    else { // axis is yaw
+      lpf(&avgSetpoint[x], state.setpoint.axis[x], FILTERCALC(state.looptime, 1.0f / (float)RELAX_FREQUENCY_HZ_YAW)); // 25 Hz filter
+      const float hpfSetpoint = state.setpoint.axis[x] - avgSetpoint[x];
+      iwindup = 1.0f - hpfSetpoint / RELAX_FACTOR_YAW;
+      if (iwindup < 0.0f) {
+        iwindup = 0.0;
+      }
+    }
+#endif
   }
 #endif
 
   // SIMPSON_RULE_INTEGRAL
-  if (!iwindup) {
-    // assuming similar time intervals
-    ierror[x] = ierror[x] + 0.166666f * (lasterror2[x] + 4 * lasterror[x] + state.error.axis[x]) * current_ki[x] * state.looptime;
-    lasterror2[x] = lasterror[x];
-    lasterror[x] = state.error.axis[x];
-  }
+  // assuming similar time intervals
+  ierror[x] = ierror[x] + 0.166666f * (lasterror2[x] + 4 * lasterror[x] + state.error.axis[x]) * current_ki[x] * iwindup * state.looptime;
+  lasterror2[x] = lasterror[x];
+  lasterror[x] = state.error.axis[x];
   limitf(&ierror[x], integrallimit[x]);
 
 #ifdef ENABLE_SETPOINT_WEIGHTING

--- a/src/main/pid.c
+++ b/src/main/pid.c
@@ -72,6 +72,9 @@ static float current_kp[PID_SIZE] = {0, 0, 0};
 static float current_ki[PID_SIZE] = {0, 0, 0};
 static float current_kd[PID_SIZE] = {0, 0, 0};
 
+static float current_kdff[PID_SIZE] = {KDFF_ROLL, KDFF_PITCH, KDFF_YAW};
+static float kdff_output[PID_SIZE] = {0, 0, 0}; // move later
+
 static float ierror[PID_SIZE] = {0, 0, 0};
 
 static float v_compensation = 1.00;
@@ -257,7 +260,9 @@ static void pid(uint8_t x) {
     state.pid_d_term.axis[x] = dlpf;
   }
 
-  state.pidoutput.axis[x] = state.pid_p_term.axis[x] + state.pid_i_term.axis[x] + state.pid_d_term.axis[x];
+  kdff_output[x] = state.setpoint.axis[x] * current_kdff[x]; // TODO add it to the states
+
+  state.pidoutput.axis[x] = state.pid_p_term.axis[x] + state.pid_i_term.axis[x] + state.pid_d_term.axis[x] + kdff_output[x];
   limitf(&state.pidoutput.axis[x], outlimit[x]);
 }
 


### PR DESCRIPTION
Changed iterm relax so that rather than an off/on case it will grow and disappear. Also added some amount of iterm relax effect to yaw, which should help with some iterm windup. Yaw has its own iterm relax values.

Added direct FF and made setpoint always calculated. This means that in angle mode dterm setpoint weight has effect in angle mode as well as direct FF. Direct FF scales with your setpoint giving a push based on how large your setpoint is. This works very well on yaw as yaw always needs some amount of push, which this can approximate. It also works well in angle mode as it allows angle mode to directly effect the rate pidsum (as now angle mode creates a setpoint) and adds an extra "kick" in angle mode that is different than what angle Pterm does. 

TODO: recode the direct ff so that it is much easier for users to tune and use. Just need to figure out the proper way that it should be done, open for help with that if this feature proves desirable.

Would love to hear users experience with both these features.