### PR TITLE
OSD changes and enable telemetry for D8, CRSF

### DIFF
--- a/src/main/control.h
+++ b/src/main/control.h
@@ -39,6 +39,7 @@ typedef struct {
   uint16_t looptime_autodetect;
   float looptime; // looptime in seconds
   float uptime;   // running sum of looptimes
+  float armtime;  // running sum of looptimes (while armed)
   float cpu_load; // micros we have had left last loop
 
   float lipo_cell_count;
@@ -89,6 +90,7 @@ typedef struct {
   MEMBER(looptime_autodetect, uint16)       \
   MEMBER(looptime, float)                   \
   MEMBER(uptime, float)                     \
+  MEMBER(armtime, float)                    \
   MEMBER(cpu_load, float)                   \
   MEMBER(lipo_cell_count, float)            \
   MEMBER(vbattfilt, float)                  \

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -192,7 +192,9 @@ int main() {
     }
 
     state.uptime += state.looptime;
-
+    if (flags.arm_state)
+      state.armtime += state.looptime;
+      
 #ifdef DEBUG
     debug.totaltime += state.looptime;
     lpf(&debug.timefilt, state.looptime, 0.998);

--- a/src/main/osd/osd_render.c
+++ b/src/main/osd/osd_render.c
@@ -179,65 +179,58 @@ uint8_t grid_selection(uint8_t element, uint8_t row) {
   }
 }
 
-//convert a time in seconds into into a 5 char array in the format mm:ss. 
+//convert a time in seconds into into a 5 char array in the format mm:ss.
 void format_time(uint8_t *str, float time_s) {
-  uint8_t minutes10;
-  uint8_t minutes1;
-  uint8_t seconds10;
-  uint8_t seconds1;
-  
   // Will only display up to 59:59 as realistically no quad will fly that long (currently). Reset to zero at on reaching 1 hr
-  while (time_s >= 3600){
+  while (time_s >= 3600) {
     time_s -= 3600;
   }
   // Surely there is a modulus operator in C??
-  minutes10 = time_s/600;
-  minutes1 = (time_s - (minutes10 * 600))/60;
-  seconds10 = (time_s - ((minutes10 * 600)+(minutes1 * 60)))/10;
-  seconds1 = time_s - ((minutes10 * 600)+(minutes1 * 60)+(seconds10 * 10));
+  uint8_t minutes10 = time_s / 600;
+  uint8_t minutes1 = (time_s - (minutes10 * 600)) / 60;
+  uint8_t seconds10 = (time_s - ((minutes10 * 600) + (minutes1 * 60))) / 10;
+  uint8_t seconds1 = time_s - ((minutes10 * 600) + (minutes1 * 60) + (seconds10 * 10));
 
   str[0] = minutes10 + 48;
   str[1] = minutes1 + 48;
-  str[2] = 58;  //:
+  str[2] = 58; //:
   str[3] = seconds10 + 48;
   str[4] = seconds1 + 48;
 }
 
 //Create a 5 char string to represent the current vtx settings in the Band:Channel:Power
 void format_vtx(uint8_t *str) {
-  switch (vtx_settings.band){
-    case 0: // VTX_BAND_A
-      str[0] = 65;
-      break; 
-    case 1: // VTX_BAND_B
-      str[0] = 66;
-      break; 
-    case 2: // VTX_BAND_E
-      str[0] = 69;
-      break; 
-    case 3: // VTX_BAND_F
-      str[0] = 70;
-      break; 
-    case 4: // VTX_BAND_R
-      str[0] = 82;
-      break; 
-    case 5: // VTX_BAND_MAX
-      str[0] = 77;  // M
-      break; 
+  switch (vtx_settings.band) {
+  case VTX_BAND_A:
+    str[0] = 65;
+    break;
+  case VTX_BAND_B:
+    str[0] = 66;
+    break;
+  case VTX_BAND_E:
+    str[0] = 69;
+    break;
+  case VTX_BAND_F:
+    str[0] = 70;
+    break;
+  case VTX_BAND_R:
+    str[0] = 82;
+    break;
+  default:
+    str[0] = 77; // M
+    break;
   }
-  str[1] = 58;  //:
+  str[1] = 58; //:
   str[2] = vtx_settings.channel + 49;
-  str[3] = 58;  //:
-  if (vtx_settings.pit_mode == 1){
-    str[4] = 21;  // "pit", probably from Pitch, but we will use it here
-  }
-  else{
+  str[3] = 58; //:
+  if (vtx_settings.pit_mode == 1) {
+    str[4] = 21; // "pit", probably from Pitch, but we will use it here
+  } else {
     if (vtx_settings.power_level == 4)
-      str[4] = 36;  // "max"
+      str[4] = 36; // "max"
     else
       str[4] = vtx_settings.power_level + 49;
   }
-  
 }
 
 //************************************************************************************************************************************************************************************
@@ -711,9 +704,7 @@ void osd_display() {
     case 6:
       if (osd_decode(*stopwatch, ACTIVE)) {
         uint8_t osd_stopwatch[5];
-        // fast_fprint(osd_stopwatch, 5, state.uptime, 0);
-        // osd_stopwatch[4] = 112; //Z+23 is fly hr
-       format_time(osd_stopwatch, state.armtime);        
+        format_time(osd_stopwatch, state.armtime);
         osd_print_data(osd_stopwatch, 5, osd_decode(*stopwatch, ATTRIBUTE), osd_decode(*stopwatch, POSITIONX), osd_decode(*stopwatch, POSITIONY));
       }
       osd_display_element++;
@@ -759,8 +750,7 @@ void osd_display() {
     case 11:
       if (osd_decode(*osd_vtx, ACTIVE) && vtx_settings.detected) {
         uint8_t osd_vtx_freq[5];
-        // fast_fprint(osd_vtx_freq, 5, vtx_frequency_from_channel(vtx_settings.band, vtx_settings.channel), 0);
-        format_vtx(osd_vtx_freq);        
+        format_vtx(osd_vtx_freq);
         osd_print_data(osd_vtx_freq, 5, osd_decode(*osd_vtx, ATTRIBUTE), osd_decode(*osd_vtx, POSITIONX), osd_decode(*osd_vtx, POSITIONY));
       }
       osd_display_element++;

--- a/src/main/osd/osd_render.c
+++ b/src/main/osd/osd_render.c
@@ -179,6 +179,67 @@ uint8_t grid_selection(uint8_t element, uint8_t row) {
   }
 }
 
+//convert a time in seconds into into a 5 char array in the format mm:ss. 
+void format_time(uint8_t *str, float time_s) {
+  uint8_t minutes10;
+  uint8_t minutes1;
+  uint8_t seconds10;
+  uint8_t seconds1;
+  
+  // Will only display up to 59:59 as realistically no quad will fly that long (currently). Reset to zero at on reaching 1 hr
+  while (time_s >= 3600){
+    time_s -= 3600;
+  }
+  // Surely there is a modulus operator in C??
+  minutes10 = time_s/600;
+  minutes1 = (time_s - (minutes10 * 600))/60;
+  seconds10 = (time_s - ((minutes10 * 600)+(minutes1 * 60)))/10;
+  seconds1 = time_s - ((minutes10 * 600)+(minutes1 * 60)+(seconds10 * 10));
+
+  str[0] = minutes10 + 48;
+  str[1] = minutes1 + 48;
+  str[2] = 58;  //:
+  str[3] = seconds10 + 48;
+  str[4] = seconds1 + 48;
+}
+
+//Create a 5 char string to represent the current vtx settings in the Band:Channel:Power
+void format_vtx(uint8_t *str) {
+  switch (vtx_settings.band){
+    case 0: // VTX_BAND_A
+      str[0] = 65;
+      break; 
+    case 1: // VTX_BAND_B
+      str[0] = 66;
+      break; 
+    case 2: // VTX_BAND_E
+      str[0] = 69;
+      break; 
+    case 3: // VTX_BAND_F
+      str[0] = 70;
+      break; 
+    case 4: // VTX_BAND_R
+      str[0] = 82;
+      break; 
+    case 5: // VTX_BAND_MAX
+      str[0] = 77;  // M
+      break; 
+  }
+  str[1] = 58;  //:
+  str[2] = vtx_settings.channel + 49;
+  str[3] = 58;  //:
+  if (vtx_settings.pit_mode == 1){
+    str[4] = 21;  // "pit", probably from Pitch, but we will use it here
+  }
+  else{
+    if (vtx_settings.power_level == 4)
+      str[4] = 36;  // "max"
+    else
+      str[4] = vtx_settings.power_level + 49;
+  }
+  
+}
+
 //************************************************************************************************************************************************************************************
 //																					PRINT FUNCTIONS
 //************************************************************************************************************************************************************************************
@@ -650,8 +711,9 @@ void osd_display() {
     case 6:
       if (osd_decode(*stopwatch, ACTIVE)) {
         uint8_t osd_stopwatch[5];
-        fast_fprint(osd_stopwatch, 5, state.uptime, 0);
-        osd_stopwatch[4] = 112; //Z+23 is fly hr
+        // fast_fprint(osd_stopwatch, 5, state.uptime, 0);
+        // osd_stopwatch[4] = 112; //Z+23 is fly hr
+       format_time(osd_stopwatch, state.armtime);        
         osd_print_data(osd_stopwatch, 5, osd_decode(*stopwatch, ATTRIBUTE), osd_decode(*stopwatch, POSITIONX), osd_decode(*stopwatch, POSITIONY));
       }
       osd_display_element++;
@@ -697,7 +759,8 @@ void osd_display() {
     case 11:
       if (osd_decode(*osd_vtx, ACTIVE) && vtx_settings.detected) {
         uint8_t osd_vtx_freq[5];
-        fast_fprint(osd_vtx_freq, 5, vtx_frequency_from_channel(vtx_settings.band, vtx_settings.channel), 0);
+        // fast_fprint(osd_vtx_freq, 5, vtx_frequency_from_channel(vtx_settings.band, vtx_settings.channel), 0);
+        format_vtx(osd_vtx_freq);        
         osd_print_data(osd_vtx_freq, 5, osd_decode(*osd_vtx, ATTRIBUTE), osd_decode(*osd_vtx, POSITIONX), osd_decode(*osd_vtx, POSITIONY));
       }
       osd_display_element++;

--- a/src/main/rx/rx_frsky_d8.c
+++ b/src/main/rx/rx_frsky_d8.c
@@ -12,10 +12,9 @@
 
 //Source https://www.rcgroups.com/forums/showpost.php?p=21864861
 
-//#ifdef USE_CC2500_PA_LNA
+// these will get absimal range without pa/lna
 #define FRSKY_ENABLE_TELEMETRY
 #define FRSKY_ENABLE_HUB_TELEMETRY
-//#endif
 
 #define FRSKY_D8_CHANNEL_COUNT 8
 #define FRSKY_D8_HUB_FIRST_USER_ID 0x31

--- a/src/main/rx/rx_frsky_d8.c
+++ b/src/main/rx/rx_frsky_d8.c
@@ -12,10 +12,10 @@
 
 //Source https://www.rcgroups.com/forums/showpost.php?p=21864861
 
-#ifdef USE_CC2500_PA_LNA
+//#ifdef USE_CC2500_PA_LNA
 #define FRSKY_ENABLE_TELEMETRY
 #define FRSKY_ENABLE_HUB_TELEMETRY
-#endif
+//#endif
 
 #define FRSKY_D8_CHANNEL_COUNT 8
 #define FRSKY_D8_HUB_FIRST_USER_ID 0x31

--- a/src/main/rx/rx_unified_crsf.c
+++ b/src/main/rx/rx_unified_crsf.c
@@ -4,8 +4,8 @@
 
 #include <stdbool.h>
 #include <stdlib.h>
-#include <string.h>
 #include <stm32f4xx_ll_usart.h>
+#include <string.h>
 
 #include "control.h"
 #include "drv_serial.h"
@@ -41,40 +41,24 @@
  */
 
 #define CRSF_FRAME_SIZE_MAX 64
-#define CRSF_PAYLOAD_SIZE_MAX   60
+#define CRSF_PAYLOAD_SIZE_MAX 60
 #define CRSF_SYNC_BYTE 0xC8
 
-typedef struct crsfFrameDef_s {
-    uint8_t deviceAddress;
-    uint8_t frameLength;
-    uint8_t type;
-    uint8_t payload[CRSF_PAYLOAD_SIZE_MAX + 1]; // +1 for CRC at end of payload
-} crsfFrameDef_t; 
- 
-
-typedef union crsfFrame_u {
-    uint8_t bytes[CRSF_FRAME_SIZE_MAX];
-    crsfFrameDef_t frame;
-} crsfFrame_t; 
-
-crsfFrame_t crsfFrame;
-//static uint8_t crsfTelemetryFrame[CRSF_FRAME_SIZE_MAX];
- 
 enum {
-    CRSF_FRAME_GPS_PAYLOAD_SIZE = 15,
-    CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE = 8,
-    CRSF_FRAME_LINK_STATISTICS_PAYLOAD_SIZE = 10,
-    CRSF_FRAME_RC_CHANNELS_PAYLOAD_SIZE = 22, // 11 bits per channel * 16 channels = 22 bytes.
-    CRSF_FRAME_ATTITUDE_PAYLOAD_SIZE = 6,
-    CRSF_FRAME_TX_MSP_FRAME_SIZE = 58,
-    CRSF_FRAME_RX_MSP_FRAME_SIZE = 8,
-    CRSF_FRAME_ORIGIN_DEST_SIZE = 2,
-    CRSF_FRAME_LENGTH_ADDRESS = 1, // length of ADDRESS field
-    CRSF_FRAME_LENGTH_FRAMELENGTH = 1, // length of FRAMELENGTH field
-    CRSF_FRAME_LENGTH_TYPE = 1, // length of TYPE field
-    CRSF_FRAME_LENGTH_CRC = 1, // length of CRC field
-    CRSF_FRAME_LENGTH_TYPE_CRC = 2, // length of TYPE and CRC fields combined
-    CRSF_FRAME_LENGTH_EXT_TYPE_CRC = 4 // length of Extended Dest/Origin, TYPE and CRC fields combined
+  CRSF_FRAME_GPS_PAYLOAD_SIZE = 15,
+  CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE = 8,
+  CRSF_FRAME_LINK_STATISTICS_PAYLOAD_SIZE = 10,
+  CRSF_FRAME_RC_CHANNELS_PAYLOAD_SIZE = 22, // 11 bits per channel * 16 channels = 22 bytes.
+  CRSF_FRAME_ATTITUDE_PAYLOAD_SIZE = 6,
+  CRSF_FRAME_TX_MSP_FRAME_SIZE = 58,
+  CRSF_FRAME_RX_MSP_FRAME_SIZE = 8,
+  CRSF_FRAME_ORIGIN_DEST_SIZE = 2,
+  CRSF_FRAME_LENGTH_ADDRESS = 1,     // length of ADDRESS field
+  CRSF_FRAME_LENGTH_FRAMELENGTH = 1, // length of FRAMELENGTH field
+  CRSF_FRAME_LENGTH_TYPE = 1,        // length of TYPE field
+  CRSF_FRAME_LENGTH_CRC = 1,         // length of CRC field
+  CRSF_FRAME_LENGTH_TYPE_CRC = 2,    // length of TYPE and CRC fields combined
+  CRSF_FRAME_LENGTH_EXT_TYPE_CRC = 4 // length of Extended Dest/Origin, TYPE and CRC fields combined
 };
 
 typedef enum {
@@ -124,10 +108,21 @@ typedef struct {
   int8_t downlink_snr;
 } crsf_stats_t;
 
+typedef struct {
+  uint8_t device_address;
+  uint8_t frame_length;
+  uint8_t type;
+  uint8_t payload[CRSF_PAYLOAD_SIZE_MAX + 1]; // +1 for CRC at end of payload
+} crsf_frame_def_t;
+
+typedef union {
+  uint8_t bytes[CRSF_FRAME_SIZE_MAX];
+  crsf_frame_def_t frame;
+} crsf_frame_t;
+
 extern uint8_t rx_buffer[RX_BUFF_SIZE];
 extern uint8_t rx_data[RX_BUFF_SIZE];
 
-//static bool crsf_debug_telemetry = false;
 static uint8_t telemetry_counter = 0;
 
 extern volatile uint8_t rx_frame_position;
@@ -319,10 +314,9 @@ void rx_serial_process_crsf() {
     //We're done with this frame now.
     frame_status = FRAME_TX;
     rx_buffer_offset = 0;
-    telemetry_counter++;   // Telemetry will send data out when this reaches 10
+    telemetry_counter++; // Telemetry will send data out when this reaches 10
   }
 }
-
 
 // Telemetry sending back to receiver (only voltage for now)
 /*
@@ -343,47 +337,50 @@ uint24_t    Fuel ( drawn mAh )
 uint8_t     Battery remaining ( percent )
 */
 
-void crsfFrameBatterySensor()
-{
-    telemetry_packet[1] = CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE + CRSF_FRAME_LENGTH_TYPE_CRC;
-    telemetry_packet[2] = CRSF_FRAMETYPE_BATTERY_SENSOR;
-    telemetry_packet[3] = (int)(state.vbatt_comp * 10) >> 8;
-    telemetry_packet[4] = (int)(state.vbatt_comp * 10);
-    telemetry_packet[5] = (int)(state.vbattfilt * 10) >> 8;
-    telemetry_packet[6] = (int)(state.vbattfilt * 10);
-    const uint32_t mAhDrawn = 0;
-    const uint8_t batteryRemainingPercentage = 0;
-    telemetry_packet[7] = mAhDrawn >> 16;
-    telemetry_packet[8] = mAhDrawn >> 8;
-    telemetry_packet[9] = mAhDrawn;
-    telemetry_packet[10] = batteryRemainingPercentage;
+static void crsf_frame_battery_sensor() {
+  telemetry_packet[1] = CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE + CRSF_FRAME_LENGTH_TYPE_CRC;
+  telemetry_packet[2] = CRSF_FRAMETYPE_BATTERY_SENSOR;
+  telemetry_packet[3] = (int)(state.vbatt_comp * 10) >> 8;
+  telemetry_packet[4] = (int)(state.vbatt_comp * 10);
+  telemetry_packet[5] = (int)(state.vbattfilt * 10) >> 8;
+  telemetry_packet[6] = (int)(state.vbattfilt * 10);
+  const uint32_t mah_drawn = 0;
+  const uint8_t battery_remaining_percentage = 0;
+  telemetry_packet[7] = mah_drawn >> 16;
+  telemetry_packet[8] = mah_drawn >> 8;
+  telemetry_packet[9] = mah_drawn;
+  telemetry_packet[10] = battery_remaining_percentage;
 }
 
-// rx_frame_position >= 41 && 
 void rx_serial_send_crsf_telemetry() {
-  if (telemetry_counter > 10 && frame_status == FRAME_TX) { // Send telemetry back once every 10 packets. This gives the RX time to send ITS telemetry back
-    telemetry_counter = 0;
-    frame_status = FRAME_DONE;
-
-    //Sync byte
-    telemetry_packet[0] = CRSF_SYNC_BYTE; 
-    crsfFrameBatterySensor();
-    //CRC byte
-    telemetry_packet[11] = crsf_crc8(&telemetry_packet[2], CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE + 1);
-
-    // QS Telemetry send function assumes 10 bytes of telemetry + the offset for escaped bytes
-    // Since we are not escaping anything, and since we know there are 12 bytes (packets) in
-    // CRSF telemetry for the battery sensor, Offset is 12-10=2
-    telemetry_offset = 2;
-
-    //Shove the packet out the UART. 
-    while (LL_USART_IsActiveFlag_TXE(USART.channel) == RESET) //just in case - but this should do nothing if ready_for_next_telemetry flag is properly cleared by irq
-      ;
-    LL_USART_TransmitData8(USART.channel, telemetry_packet[0]);
-    ready_for_next_telemetry = 0;
-    LL_USART_EnableIT_TC(USART.channel); //turn on the transmit transfer complete interrupt so that the rest of the telemetry packet gets sent
-    //That's it, telemetry has sent the first byte - the rest will be sent by the telemetry tx irq  
+  // Send telemetry back once every 10 packets. This gives the RX time to send ITS telemetry back
+  if (telemetry_counter <= 10 || frame_status != FRAME_TX) {
+    return;
   }
+
+  telemetry_counter = 0;
+  frame_status = FRAME_DONE;
+
+  //Sync byte
+  telemetry_packet[0] = CRSF_SYNC_BYTE;
+  crsf_frame_battery_sensor();
+  //CRC byte
+  telemetry_packet[11] = crsf_crc8(&telemetry_packet[2], CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE + 1);
+
+  // QS Telemetry send function assumes 10 bytes of telemetry + the offset for escaped bytes
+  // Since we are not escaping anything, and since we know there are 12 bytes (packets) in
+  // CRSF telemetry for the battery sensor, Offset is 12-10=2
+  telemetry_offset = 2;
+
+  //Shove the packet out the UART.
+  while (LL_USART_IsActiveFlag_TXE(USART.channel) == RESET)
+    ;
+  LL_USART_TransmitData8(USART.channel, telemetry_packet[0]);
+  ready_for_next_telemetry = 0;
+
+  //turn on the transmit transfer complete interrupt so that the rest of the telemetry packet gets sent
+  //That's it, telemetry has sent the first byte - the rest will be sent by the telemetry tx irq
+  LL_USART_EnableIT_TC(USART.channel);
 }
 
 #endif

--- a/src/main/rx/rx_unified_serial.c
+++ b/src/main/rx/rx_unified_serial.c
@@ -60,7 +60,8 @@ void TX_USART_ISR() {
   // reset this to 0 so that a protocol switch will not create a tx isr that does stuff without need
   uint8_t bytes_to_send = 0;
   if (bind_storage.unified.protocol == RX_SERIAL_PROTOCOL_FPORT ||
-      bind_storage.unified.protocol == RX_SERIAL_PROTOCOL_FPORT_INVERTED) {
++     bind_storage.unified.protocol == RX_SERIAL_PROTOCOL_FPORT_INVERTED ||
+      bind_storage.unified.protocol == RX_SERIAL_PROTOCOL_CRSF ) {
     //upload total telemetry bytes to send so telemetry transmit triggers action appropriate to protocol
     bytes_to_send = 10 + telemetry_offset;
   }
@@ -315,8 +316,10 @@ void rx_check() {
         frame_status = FRAME_DONE;
       break;
     case RX_SERIAL_PROTOCOL_CRSF:
-      //CRSF telemetry function call yo
-      frame_status = FRAME_DONE;
+      if (ready_for_next_telemetry)
+        rx_serial_send_crsf_telemetry();
+      else
+        frame_status = FRAME_DONE;
       break;
 
     default:

--- a/src/main/rx/rx_unified_serial.h
+++ b/src/main/rx/rx_unified_serial.h
@@ -40,6 +40,7 @@ void rx_serial_process_crsf();
 void rx_serial_process_redpine();
 
 void rx_serial_send_fport_telemetry();
+void rx_serial_send_crsf_telemetry();
 
 void rx_lqi_lost_packet();
 void rx_lqi_got_packet();


### PR DESCRIPTION
Display arming time on OSD (in mm:ss format), also display VTX channel as Band:Channel:Power since most people tune their goggles via band/channel not frequency (previously requested by a few racers).
I also enabled telemetry in D8, not sure why it was disabled but i like that audible confirmation of the link, and voltage callouts
Similarly i added telemetry to CRSF since i like to have that downlink enabled too....