### PR TITLE
Fix typo in imu_init for quicksilver imu

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -69,7 +69,7 @@ void imu_init() {
 
 #ifdef QUICKSILVER_IMU
   filter_lp_pt1_init(&filter, filter_pass1, 3, PT1_FILTER_HZ);
-  filter_lp_pt1_init(&filter, filter_pass1, 3, PT1_FILTER_HZ);
+  filter_lp_pt1_init(&filter, filter_pass2, 3, PT1_FILTER_HZ);
 #endif
 }
 


### PR DESCRIPTION
While reviewing the code to familiarize myself with it, I found the second pass in both develop and master is it initialized using filter_lp_pt1_init. I've fixed this on develop, but it could be easily fixed in the master branch in the same fashion.