### PR TITLE
Added Matekf411rx FrSky D16 config

### DIFF
--- a/script/targets.json
+++ b/script/targets.json
@@ -39,21 +39,21 @@
     "name": "matekf411rx",
     "configurations": [
       {
-        "name": "brushed.frsky",
+        "name": "brushed.frsky_d8",
         "defines": {
           "BRUSHED_TARGET": "",
           "RX_FRSKY_D8": ""
         }
       },
       {
-        "name": "brushless.frsky",
+        "name": "brushless.frsky_d8",
         "defines": {
           "BRUSHLESS_TARGET": "",
           "RX_FRSKY_D8": ""
         }
       },
       {
-        "name": "brushless.accst",
+        "name": "brushless.frsky_d16_fcc",
         "defines": {
           "BRUSHLESS_TARGET": "",
           "RX_FRSKY_D16_FCC": ""

--- a/script/targets.json
+++ b/script/targets.json
@@ -53,6 +53,13 @@
         }
       },
       {
+        "name": "brushless.accst",
+        "defines": {
+          "BRUSHLESS_TARGET": "",
+          "RX_FRSKY_D16_FCC": ""
+        }
+      },
+      {
         "name": "brushless.redpine",
         "defines": {
           "BRUSHLESS_TARGET": "",


### PR DESCRIPTION
The Emax Tinyhawk S has an RX SPI D8/D16 and the QS flash with D8 target did not work properly, with this new D16 configuration the QS worked very well.