### PR TITLE
Repair Bayang support. Fixes compilation errors when defining and bui…

### DIFF
--- a/src/config/profile.c
+++ b/src/config/profile.c
@@ -415,6 +415,12 @@ const profile_t default_profile = {
         .protocol = RX_PROTOCOL_REDPINE,
 #elif defined(RX_FLYSKY)
         .protocol = RX_PROTOCOL_FLYSKY_AFHDS2A,
+#elif defined(RX_NRF24_BAYANG_TELEMETRY)        
+        .protocol = RX_PROTOCOL_NRF24_BAYANG_TELEMETRY,
+#elif defined(RX_BAYANG_PROTOCOL_BLE_BEACON)        
+        .protocol = RX_PROTOCOL_BAYANG_PROTOCOL_BLE_BEACON,
+#elif defined(RX_BAYANG_PROTOCOL_TELEMETRY_AUTOBIND)        
+        .protocol = RX_PROTOCOL_BAYANG_PROTOCOL_TELEMETRY_AUTOBIND,
 #else
         .protocol = RX_PROTOCOL_UNIFIED_SERIAL,
 #endif
@@ -511,6 +517,16 @@ target_info_t target_info = {
     ,
     .rx_protocols = {
         RX_PROTOCOL_UNIFIED_SERIAL,
+
+#if defined(RX_NRF24_BAYANG_TELEMETRY)        
+        RX_PROTOCOL_NRF24_BAYANG_TELEMETRY,
+#endif
+#if defined(RX_BAYANG_PROTOCOL_BLE_BEACON)        
+        RX_PROTOCOL_BAYANG_PROTOCOL_BLE_BEACON,
+#endif        
+#if defined(RX_BAYANG_PROTOCOL_TELEMETRY_AUTOBIND)        
+        RX_PROTOCOL_BAYANG_PROTOCOL_TELEMETRY_AUTOBIND,
+#endif
 
 #if defined(RX_FRSKY)
         RX_PROTOCOL_FRSKY_D8,

--- a/src/drivers/drv_spi_soft_3wire.c
+++ b/src/drivers/drv_spi_soft_3wire.c
@@ -1,5 +1,4 @@
-#include "drv_spi.h"
-
+#include "drv_spi_soft.h"
 #include "drv_time.h"
 #include "project.h"
 

--- a/src/drivers/drv_spi_soft_4wire.c
+++ b/src/drivers/drv_spi_soft_4wire.c
@@ -1,5 +1,4 @@
-#include "drv_spi.h"
-
+#include "drv_spi_soft.h"
 #include "project.h"
 
 #ifdef USE_SOFT_SPI_4WIRE

--- a/src/rx/rx.c
+++ b/src/rx/rx.c
@@ -201,12 +201,17 @@ void rx_init() {
   case RX_PROTOCOL_IBUS:
   case RX_PROTOCOL_FPORT:
   case RX_PROTOCOL_DSM:
+#ifdef SERIAL_RX
     rx_serial_init();
+#endif    
     break;
 
   case RX_PROTOCOL_NRF24_BAYANG_TELEMETRY:
   case RX_PROTOCOL_BAYANG_PROTOCOL_BLE_BEACON:
   case RX_PROTOCOL_BAYANG_PROTOCOL_TELEMETRY_AUTOBIND:
+#if defined(RX_NRF24_BAYANG_TELEMETRY) || defined(RX_PROTOCOL_BAYANG_PROTOCOL_BLE_BEACON) || defined(RX_BAYANG_PROTOCOL_TELEMETRY_AUTOBIND)
+    rx_protocol_init();
+#endif    
     break;
 
   case RX_PROTOCOL_FRSKY_D8:
@@ -277,12 +282,20 @@ bool rx_check() {
   case RX_PROTOCOL_IBUS:
   case RX_PROTOCOL_FPORT:
   case RX_PROTOCOL_DSM:
+#ifdef SERIAL_RX
     return rx_serial_check();
+#else
+    return false;    
+#endif    
 
   case RX_PROTOCOL_NRF24_BAYANG_TELEMETRY:
   case RX_PROTOCOL_BAYANG_PROTOCOL_BLE_BEACON:
   case RX_PROTOCOL_BAYANG_PROTOCOL_TELEMETRY_AUTOBIND:
-    return false;
+#if defined(RX_NRF24_BAYANG_TELEMETRY) || defined(RX_PROTOCOL_BAYANG_PROTOCOL_BLE_BEACON) || defined(RX_BAYANG_PROTOCOL_TELEMETRY_AUTOBIND)
+    return rx_bayang_check();
+#else
+    return false;    
+#endif
 
   case RX_PROTOCOL_FRSKY_D8:
 #ifdef RX_FRSKY

--- a/src/rx/rx_bayang.h
+++ b/src/rx/rx_bayang.h
@@ -68,7 +68,7 @@ typedef struct {
 } rx_bayang_bind_data_t;
 
 void rx_protocol_init();
-bool rx_check();
+bool rx_bayang_check();
 
 struct rxdebug {
   uint32_t packettime;

--- a/src/rx/rx_bayang_ble_app.c
+++ b/src/rx/rx_bayang_ble_app.c
@@ -13,7 +13,7 @@
 
 #include <stdio.h>
 
-#include "drv_spi.h"
+#include "drv_spi_soft.h"
 #include "drv_spi_xn297.h"
 #include "drv_time.h"
 #include "failloop.h"
@@ -136,7 +136,7 @@ char lasttrim[4];
 char rfchannel[4];
 int rxaddress[5];
 int rf_chan = 0;
-int bind_safety = 0;
+uint16_t bind_safety = 0;
 
 uint32_t total_time_in_air = 0;
 uint32_t time_throttle_on = 0;
@@ -917,7 +917,7 @@ int lastrxchan;
 int timingfail = 0;
 extern int bound_for_BLE_packet; // SilverVISE
 
-bool rx_check() {
+bool rx_bayang_check() {
   bool channels_received = false;
 
   int packetreceived = checkpacket();

--- a/src/rx/rx_bayang_protocol_ble.c
+++ b/src/rx/rx_bayang_protocol_ble.c
@@ -2,7 +2,7 @@
 
 #include <stdio.h>
 
-#include "drv_spi.h"
+#include "drv_spi_soft.h"
 #include "drv_spi_xn297.h"
 #include "drv_time.h"
 #include "failloop.h"
@@ -22,7 +22,7 @@
 char rfchannel[4];
 int rxaddress[5];
 int rf_chan = 0;
-int bind_safety = 0;
+uint16_t bind_safety = 0;
 
 void bleinit();
 
@@ -185,7 +185,7 @@ const uint8_t xn297_scramble_rev[] = {
 
 // whitening sequence for adv channel 37 (rf chan 2402)
 // for speed
-const uint8 ble_whiten_37[] = {
+const uint8_t ble_whiten_37[] = {
     0x8D, 0xd2, 0x57, 0xa1, 0x3d, 0xa7, 0x66, 0xb0,
     0x75, 0x31, 0x11, 0x48, 0x96, 0x77, 0xf8, 0xe3,
     0x46, 0xe9, 0xab, 0xd0, 0x9e, 0x53, 0x33, 0xd8,
@@ -571,7 +571,7 @@ int timingfail = 0;
 // how many times to hop ahead if no reception
 #define HOPPING_NUMBER 4
 
-bool rx_check() {
+bool rx_bayang_check() {
   bool channels_received = false;
 
   int packetreceived = checkpacket();

--- a/src/rx/rx_bayang_protocol_telemetry_autobind.c
+++ b/src/rx/rx_bayang_protocol_telemetry_autobind.c
@@ -2,7 +2,7 @@
 
 #include <stdio.h>
 
-#include "drv_spi.h"
+#include "drv_spi_soft.h"
 #include "drv_spi_xn297.h"
 #include "drv_time.h"
 #include "failloop.h"
@@ -35,7 +35,7 @@ char lasttrim[4];
 int rx_bind_load = 0;
 
 int rf_chan = 0;
-int bind_safety = 0;
+uint16_t bind_safety = 0;
 
 uint32_t autobindtime = 0;
 int autobind_inhibit = 0;
@@ -361,7 +361,7 @@ uint32_t skipchannel = 0;
 int lastrxchan;
 int timingfail = 0;
 
-bool rx_check() {
+bool rx_bayang_check() {
   bool channels_received = false;
 
   int packetreceived = checkpacket();

--- a/src/rx/rx_nrf24_bayang_telemetry.c
+++ b/src/rx/rx_nrf24_bayang_telemetry.c
@@ -2,7 +2,7 @@
 
 #include <stdio.h>
 
-#include "drv_spi.h"
+#include "drv_spi_soft.h"
 #include "drv_spi_xn297.h"
 #include "drv_time.h"
 #include "failloop.h"
@@ -142,7 +142,7 @@ char lasttrim[4];
 char rfchannel[4];
 int rxaddress[5];
 int rf_chan = 0;
-int bind_safety = 0;
+uint16_t bind_safety = 0;
 int rxdata[17 + 2 * crc_en];
 
 void rx_protocol_init() {
@@ -365,7 +365,7 @@ int packet_period = PACKET_PERIOD;
 uint8_t rxaddr[5];
 int packets = 0;
 
-bool rx_check() {
+bool rx_bayang_check() {
   bool channels_received = false;
 
   int packetreceived = checkpacket();
@@ -377,7 +377,7 @@ bool rx_check() {
       if (nrf24_read_xn297_payload(rxdata, 15 + 2 * crc_en))
         ;
       else
-        return;
+        return channels_received;
 
       if (rxdata[0] == 0xa4 || rxdata[0] == 0xa3) { // bind packet
         if (rxdata[0] == 0xa3) {

--- a/src/rx/rx_unified_serial.c
+++ b/src/rx/rx_unified_serial.c
@@ -15,6 +15,8 @@
 #include "util/circular_buffer.h"
 #include "util/util.h"
 
+#ifdef SERIAL_RX
+
 #define USART usart_port_defs[serial_rx_port]
 
 // This is the microsecond threshold for triggering a new frame to re-index to position 0 in the ISR
@@ -375,3 +377,5 @@ void rx_serial_find_protocol() {
     protocol_detect_timer = 0;        // Reset timer, triggering a shift to detecting the next protocol
   }
 }
+
+#endif  // #ifdef SERIAL_RX


### PR DESCRIPTION
Repair Bayang support. 

Fixes compilation errors when defining and building  for one of: RX_BAYANG_PROTOCOL_BLE_BEACON, RX_BAYANG_PROTOCOL_TELEMETRY_AUTOBIND, RX_NRF24_BAYANG_TELEMETRY.

Also ensures configurator is aware of the configured Bayang protocol.

Also fixes compile issues when RX_SERIAL is disabled (not defined), which is something you'll likely do when using BAYANG so you can use available RX and TX pads for SPI connection to XN297 or NRF24L01

