### PR TITLE
turtle: clear turtle_ready flag when quad is right side up

### DIFF
--- a/src/flight/turtle_mode.c
+++ b/src/flight/turtle_mode.c
@@ -25,10 +25,14 @@ static uint8_t turtle_axis = 0;
 static uint8_t turtle_dir = 0;
 
 void turtle_mode_start() {
-  if (!flags.turtle_ready && flags.on_ground && turtle_state == TURTLE_STAGE_IDLE && (state.GEstG.yaw < 0)) {
-    // only enable turtle if we are onground and not recovering from a interrupted turtle
-    flags.turtle_ready = 1;
-  }
+  if (flags.on_ground && turtle_state == TURTLE_STAGE_IDLE) {
+    if (state.GEstG.yaw < 0) {
+      // only enable turtle if we are onground
+      flags.turtle_ready = 1;
+    } else {
+      flags.turtle_ready = 0;
+    }
+  } 
 }
 
 void turtle_mode_cancel() {


### PR DESCRIPTION
## Description
Currently the turtle_ready flag is only cleared if turtle action succeeds
if the action fails and you manually flip the drone over the turtle_ready
flag is stuck on. If the initial motor direction fails, the next attempt
to set the flag when armed will not run with flag set. This clears the flag
to allow the motor direction change to work.

## Tested on:
* BetaFPV F4 1S AIO with SPI ELRS
* BlueJay 0.18.1 96kHz ESC firmware
* Meteor65 Pro with 35mm prop frame

## Testing Steps
### Flip Successful
1. With Turtle Mode Switch On
2. Arm in normal orientation and verify that drone flies
3. Flip drone upside down
4. Arm and verify that drone is in turtle mode
5. Flip drone over
6. Disarm
7. Validate that drone flies

### Turtle Failed Test
1. With Turtle Mode Switch On
2. Put drone upside down
3. Block drone from flipping over by placing something on top
4. Arm
5. Start Turtle in a direction
6. Before timeout disarm quad
7. Manually flip drone over
8. Arm
9. Validate drone flies in correct direction