### PR TITLE
adjust serial 4 way pass-through order to match with profile

### DIFF
--- a/src/driver/serial_4way.c
+++ b/src/driver/serial_4way.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "core/debug.h"
+#include "core/profile.h"
 #include "driver/gpio.h"
 #include "driver/motor.h"
 #include "driver/serial_4way.h"
@@ -132,7 +133,7 @@ uint8_t serial_4way_init() {
   time_delay_ms(250);
 
   for (uint32_t i = 0; i < MOTOR_PIN_MAX; i++) {
-    const gpio_pins_t pin = target.motor_pins[i];
+    const gpio_pins_t pin = target.motor_pins[profile.motor.motor_pins[i]];
     esc_pins[i] = pin;
     avr_bl_init_pin(pin);
   }

--- a/src/io/quic.h
+++ b/src/io/quic.h
@@ -8,7 +8,7 @@
 #define QUIC_MAGIC '#'
 #define QUIC_HEADER_LEN 4
 
-#define QUIC_PROTOCOL_VERSION MAKE_SEMVER(0, 2, 1)
+#define QUIC_PROTOCOL_VERSION MAKE_SEMVER(0, 2, 2)
 
 typedef enum {
   QUIC_CMD_INVALID,


### PR DESCRIPTION
Currently the pass-through is in the order of the target file, which makes it inconvient.
Adjust serial 4 way pass-through order to match with profile.