### PR TITLE
Add filltered voltage warnings

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -148,6 +148,9 @@
 #define ACTUAL_BATTERY_VOLTAGE 4.20
 #define REPORTED_TELEMETRY_VOLTAGE 4.20
 
+// *************Use filtered voltage instead of fuel gauge voltage for low battery warnings
+#define USE_FILTERED_VOLTAGE_FOR_WARNINGS 0
+
 //**********************************************************************************************************************
 //***********************************************FILTER SETTINGS********************************************************
 

--- a/src/core/profile.c
+++ b/src/core/profile.c
@@ -383,6 +383,7 @@ const profile_t default_profile = {
         .vbattlow = VBATTLOW,
         .actual_battery_voltage = ACTUAL_BATTERY_VOLTAGE,
         .reported_telemetry_voltage = REPORTED_TELEMETRY_VOLTAGE,
+        .use_filtered_voltage_for_warnings = USE_FILTERED_VOLTAGE_FOR_WARNINGS,
         .vbat_scale = 110,
 #ifdef IBAT_SCALE
         .ibat_scale = IBAT_SCALE,

--- a/src/core/profile.h
+++ b/src/core/profile.h
@@ -224,6 +224,7 @@ typedef struct {
   float vbattlow;
   float actual_battery_voltage;
   float reported_telemetry_voltage;
+  uint8_t use_filtered_voltage_for_warnings;
   float vbat_scale;
   float ibat_scale;
 } profile_voltage_t;
@@ -235,6 +236,7 @@ typedef struct {
   MEMBER(vbattlow, float)                   \
   MEMBER(actual_battery_voltage, float)     \
   MEMBER(reported_telemetry_voltage, float) \
+  MEMBER(use_filtered_voltage_for_warnings, uint8_t) \
   MEMBER(vbat_scale, float)                 \
   MEMBER(ibat_scale, float)                 \
   END_STRUCT()

--- a/src/io/vbat.c
+++ b/src/io/vbat.c
@@ -115,8 +115,13 @@ void vbat_calc() {
   state.vbat_compensated = tempvolt + vdrop_factor * thrfilt;
   state.vbat_compensated_cell_avg = state.vbat_compensated / (float)state.lipo_cell_count;
 
-  if ((state.vbat_compensated_cell_avg < profile.voltage.vbattlow + hyst) || (state.vbat_cell_avg < VBATTLOW_ABS))
-    flags.lowbatt = 1;
-  else
-    flags.lowbatt = 0;
+
+  if (profile.voltage.use_filtered_voltage_for_warnings) {
+    flags.lowbatt = state.vbat_cell_avg < profile.voltage.vbattlow ? 1 : 0;
+  } else {
+    if ((state.vbat_compensated_cell_avg < profile.voltage.vbattlow + hyst) || (state.vbat_cell_avg < VBATTLOW_ABS))
+      flags.lowbatt = 1;
+    else
+      flags.lowbatt = 0;
+  }
 }


### PR DESCRIPTION
Adds switch that allows using filtered voltage for warnings instead of fuel-gauge voltage.

Fixes #73 

Related configurator pull request: TBD 