### PR TITLE
Update render.c to stop incorrectly limiting OSD element X positions

### DIFF
--- a/src/osd/render.c
+++ b/src/osd/render.c
@@ -1067,9 +1067,9 @@ void osd_display() {
       osd_menu_select(3, OSD_AUTO, osd_element_labels[i]);
       if (osd_menu_select_int(20, OSD_AUTO, pos_x(el), 3)) {
         if (osd_system == OSD_SYS_HD)
-          el->pos_hd_x = osd_menu_adjust_int(el->pos_hd_x, 1, 0, HD_ROWS);
+          el->pos_hd_x = osd_menu_adjust_int(el->pos_hd_x, 1, 0, HD_COLS);
         else
-          el->pos_sd_x = osd_menu_adjust_int(el->pos_sd_x, 1, 0, SD_ROWS);
+          el->pos_sd_x = osd_menu_adjust_int(el->pos_sd_x, 1, 0, SD_COLS);
       }
       if (osd_menu_select_int(26, OSD_AUTO, pos_y(el), 3)) {
         if (osd_system == OSD_SYS_HD)


### PR DESCRIPTION
pos_hd_x and pos_sd_x were being limited to HD_ROWS and SD_ROWS (instead of HD_COLS and SD_COLS)