### PR TITLE
Add control 'Stress' (I-term windup) OSD element. 

### DIFF
--- a/src/osd/render.h
+++ b/src/osd/render.h
@@ -73,7 +73,6 @@ typedef enum {
   OSD_CROSSHAIR,
   OSD_CURRENT_DRAWN,
   OSD_WATTS,
-  OSD_MAX_MOTOR,
   OSD_WINDUP,
   OSD_ELEMENT_MAX
 } osd_elements_t;


### PR DESCRIPTION
### Added OSD element 'Stress' for I-term windup monitoring
This PR adds a new OSD element that displays I-term windup as a percentage of Quicksilver's maximum I-term limits. The element is labeled "STRESS" in the OSD configuration menu and displays on screen as a percentage followed by an exclamation mark (!) to provide pilots with intuitive feedback on flight controller performance.

**How it works**
- Calculates I-term magnitude using the vector sum of roll, pitch, and yaw I-terms
- Displays as percentage relative to configured maximum I-term values (0.8, 0.8, 0.6 for roll, pitch, yaw)
- Updates every 3 seconds showing peak stress value during that period
- Resets when disarmed or on ground
- Format: displays as "XX!" (e.g., "85!" for 85% stress)
- Shows "0!" when disarmed or on ground

**Benefit for pilots**
The "Stress" label makes it more intuitive for pilots to understand what this metric represents without needing control theory knowledge. The stress percentage shows how hard the flight controller is working to maintain the desired attitude, helping with:

- **Tuning validation** - persistent high stress indicates suboptimal PID settings that need adjustment and can be used in the field.
- **Flight analysis** - brief stress spikes during aggressive manoeuvres are normal, but sustained high values suggest the quad is being pushed beyond its effective control authority
- **Performance monitoring** - like physical stress, it's okay to be stressed briefly during hard manoeuvres, but constant stress indicates something needs attention

The 3-second update window and peak-value tracking allows pilots to perform aggressive manoeuvres and see the maximum stress reached without being distracted. The exclamation mark was the best available char that gets the meaning across.